### PR TITLE
feature/#59 Email 인증 코드 입력 컴포넌트

### DIFF
--- a/client/src/common/form-component/CustomForm.tsx
+++ b/client/src/common/form-component/CustomForm.tsx
@@ -5,9 +5,14 @@ import { FormInputType } from '@/types/types';
 interface FormProps {
   children?: React.ReactNode;
   onSubmit: (data: FormInputType) => void;
+  isDisabled?: boolean;
 }
 
-const CustomForm: React.FC<FormProps> = ({ children, onSubmit }) => {
+const CustomForm: React.FC<FormProps> = ({
+  children,
+  onSubmit,
+  isDisabled,
+}) => {
   const {
     register,
     handleSubmit,

--- a/client/src/common/form-component/CustomFormStyle.tsx
+++ b/client/src/common/form-component/CustomFormStyle.tsx
@@ -48,24 +48,6 @@ const StyledForm = styled.form`
     margin-bottom: 4rem;
   }
 
-  & button[type='submit'] {
-    width: 100%;
-    height: 2.6rem;
-    border: ${(props) => `1px solid ${props.theme.point2}`};
-    border-radius: 2.6rem;
-    margin-bottom: 1.5rem;
-    font-size: 1.2rem;
-    background-color: ${(props) => props.theme.point2};
-    color: white;
-    opacity: 0.7;
-    cursor: pointer;
-    transition: opacity 0.2s linear;
-
-    &:hover {
-      opacity: 1;
-    }
-  }
-
   & p {
     color: red;
     font-size: 1.2rem;

--- a/client/src/common/form-component/CustomFormStyle.tsx
+++ b/client/src/common/form-component/CustomFormStyle.tsx
@@ -27,7 +27,7 @@ const StyledForm = styled.form`
   & input {
     font-size: 1.2rem;
     width: 100%;
-    border-bottom: 1px solid black;
+    border-bottom: 3px solid black;
 
     :-webkit-autofill,
     :-webkit-autofill:hover,
@@ -37,6 +37,10 @@ const StyledForm = styled.form`
       -webkit-transition: background-color 9999s ease-out;
       -webkit-box-shadow: 0 0 0px 1000px white inset !important;
       box-shadow: 0 0 0px white inset !important;
+    }
+
+    &:focus {
+      border-bottom: 3px solid ${(props) => props.theme.point3};
     }
   }
 

--- a/client/src/pages/login-page/components/LoginForm.tsx
+++ b/client/src/pages/login-page/components/LoginForm.tsx
@@ -1,6 +1,7 @@
 import GithubOAuth from './GithubOAuth';
 import CustomForm from '@/common/form-component/CustomForm';
 import { FormInputType } from '@/types/types';
+import { LoginButton } from './LoginFormStyle';
 
 const LoginForm: React.FC = () => {
   const onSubmit = (data: FormInputType) => {
@@ -9,7 +10,7 @@ const LoginForm: React.FC = () => {
 
   return (
     <CustomForm onSubmit={onSubmit}>
-      <button type="submit">Login</button>
+      <LoginButton type="submit">Login</LoginButton>
       <GithubOAuth />
     </CustomForm>
   );

--- a/client/src/pages/login-page/components/LoginFormStyle.tsx
+++ b/client/src/pages/login-page/components/LoginFormStyle.tsx
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+
+export const LoginButton = styled.button`
+  width: 100%;
+  height: 2.6rem;
+  border: ${(props) => `1px solid ${props.theme.point2}`};
+  border-radius: 2.6rem;
+  margin-bottom: 1.5rem;
+  font-size: 1.2rem;
+  background-color: ${(props) => props.theme.point2};
+  color: white;
+  opacity: 0.7;
+  cursor: pointer;
+  transition: opacity 0.2s linear;
+
+  &:hover {
+    opacity: 1;
+  }
+`;

--- a/client/src/pages/register-page/RegisterPage.tsx
+++ b/client/src/pages/register-page/RegisterPage.tsx
@@ -8,7 +8,7 @@ const RegisterPage: React.FC = () => {
 
   return (
     <Wrapper>
-      <RegisterForm emailCertificate={setIsSend} />
+      <RegisterForm emailCertificate={setIsSend} sendingStatus={isSend} />
       {isSend && <EmailCertificationForm />}
     </Wrapper>
   );

--- a/client/src/pages/register-page/RegisterPage.tsx
+++ b/client/src/pages/register-page/RegisterPage.tsx
@@ -1,10 +1,15 @@
 import Wrapper from './RegisterPageStyle';
 import RegisterForm from './components/RegisterForm';
+import EmailCertificationForm from './components/EmailCertificationForm';
+import { useState } from 'react';
 
 const RegisterPage: React.FC = () => {
+  const [isSend, setIsSend] = useState<boolean>(false);
+
   return (
     <Wrapper>
-      <RegisterForm />
+      <RegisterForm emailCertificate={setIsSend} />
+      {isSend && <EmailCertificationForm />}
     </Wrapper>
   );
 };

--- a/client/src/pages/register-page/RegisterPageStyle.tsx
+++ b/client/src/pages/register-page/RegisterPageStyle.tsx
@@ -5,6 +5,7 @@ const Wrapper = styled.div`
   height: 100vh;
   justify-content: center;
   align-items: center;
+  flex-direction: column;
 `;
 
 export default Wrapper;

--- a/client/src/pages/register-page/components/EmailCertificationForm.tsx
+++ b/client/src/pages/register-page/components/EmailCertificationForm.tsx
@@ -1,8 +1,10 @@
+import { CodeInput, SubmitButton } from './EmailCertificationFormStyle';
+
 const EmailCertificationForm: React.FC = () => {
   return (
     <>
-      <input type="text" />
-      <button>인증</button>
+      <CodeInput type="text" placeholder="인증코드 입력" />
+      <SubmitButton>인증</SubmitButton>
     </>
   );
 };

--- a/client/src/pages/register-page/components/EmailCertificationForm.tsx
+++ b/client/src/pages/register-page/components/EmailCertificationForm.tsx
@@ -1,0 +1,10 @@
+const EmailCertificationForm: React.FC = () => {
+  return (
+    <>
+      <input type="text" />
+      <button>인증</button>
+    </>
+  );
+};
+
+export default EmailCertificationForm;

--- a/client/src/pages/register-page/components/EmailCertificationFormStyle.tsx
+++ b/client/src/pages/register-page/components/EmailCertificationFormStyle.tsx
@@ -1,0 +1,29 @@
+import styled from 'styled-components';
+
+export const CodeInput = styled.input`
+  width: 23rem;
+  height: 2.6rem;
+  border-bottom: 3px solid black;
+  font-size: 1.2rem;
+  text-align: center;
+  margin-bottom: 1rem;
+
+  &:focus {
+    border-bottom: 3px solid ${(props) => props.theme.point3};
+  }
+`;
+
+export const SubmitButton = styled.button`
+  width: 23rem;
+  height: 2.6rem;
+  border-radius: 2.6rem;
+  background-color: ${(props) => props.theme.point1};
+  font-size: 1.2rem;
+  opacity: 0.7;
+  color: #fff;
+  transition: opacity 0.2s linear;
+
+  &:hover {
+    opacity: 1;
+  }
+`;

--- a/client/src/pages/register-page/components/EmailCertificationFormStyle.tsx
+++ b/client/src/pages/register-page/components/EmailCertificationFormStyle.tsx
@@ -6,7 +6,7 @@ export const CodeInput = styled.input`
   border-bottom: 3px solid black;
   font-size: 1.2rem;
   text-align: center;
-  margin-bottom: 1rem;
+  margin-bottom: 1.4rem;
 
   &:focus {
     border-bottom: 3px solid ${(props) => props.theme.point3};

--- a/client/src/pages/register-page/components/RegisterForm.tsx
+++ b/client/src/pages/register-page/components/RegisterForm.tsx
@@ -1,5 +1,7 @@
 import { FormInputType } from '@/types/types';
 import CustomForm from '@/common/form-component/CustomForm';
+import { RegisterButton } from './RegisterFormStyle';
+import { useEffect, useRef } from 'react';
 
 interface RegisterProps {
   emailCertificate: React.Dispatch<React.SetStateAction<boolean>>;
@@ -10,16 +12,22 @@ const RegisterForm: React.FC<RegisterProps> = ({
   emailCertificate,
   sendingStatus,
 }) => {
+  const buttonRef = useRef() as React.MutableRefObject<HTMLButtonElement>;
+
   const onSubmit = (data: FormInputType) => {
     console.log(data);
     emailCertificate(true);
   };
 
+  useEffect(() => {
+    buttonRef.current.disabled = sendingStatus;
+  }, [sendingStatus]);
+
   return (
     <CustomForm onSubmit={onSubmit}>
-      <button type="submit">
+      <RegisterButton type="submit" isDisabled={sendingStatus} ref={buttonRef}>
         {!sendingStatus ? '회원가입' : '이메일이 전송됐습니다.'}
-      </button>
+      </RegisterButton>
     </CustomForm>
   );
 };

--- a/client/src/pages/register-page/components/RegisterForm.tsx
+++ b/client/src/pages/register-page/components/RegisterForm.tsx
@@ -3,9 +3,13 @@ import CustomForm from '@/common/form-component/CustomForm';
 
 interface RegisterProps {
   emailCertificate: React.Dispatch<React.SetStateAction<boolean>>;
+  sendingStatus: boolean;
 }
 
-const RegisterForm: React.FC<RegisterProps> = ({ emailCertificate }) => {
+const RegisterForm: React.FC<RegisterProps> = ({
+  emailCertificate,
+  sendingStatus,
+}) => {
   const onSubmit = (data: FormInputType) => {
     console.log(data);
     emailCertificate(true);
@@ -13,7 +17,9 @@ const RegisterForm: React.FC<RegisterProps> = ({ emailCertificate }) => {
 
   return (
     <CustomForm onSubmit={onSubmit}>
-      <button type="submit">회원가입</button>
+      <button type="submit">
+        {!sendingStatus ? '회원가입' : '이메일이 전송됐습니다.'}
+      </button>
     </CustomForm>
   );
 };

--- a/client/src/pages/register-page/components/RegisterForm.tsx
+++ b/client/src/pages/register-page/components/RegisterForm.tsx
@@ -1,9 +1,14 @@
 import { FormInputType } from '@/types/types';
 import CustomForm from '@/common/form-component/CustomForm';
 
-const RegisterForm = () => {
+interface RegisterProps {
+  emailCertificate: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const RegisterForm: React.FC<RegisterProps> = ({ emailCertificate }) => {
   const onSubmit = (data: FormInputType) => {
     console.log(data);
+    emailCertificate(true);
   };
 
   return (

--- a/client/src/pages/register-page/components/RegisterFormStyle.tsx
+++ b/client/src/pages/register-page/components/RegisterFormStyle.tsx
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+
+interface RegisterButtonProps {
+  isDisabled: boolean;
+}
+
+export const RegisterButton = styled.button<RegisterButtonProps>`
+  width: 100%;
+  height: 2.6rem;
+  border: ${(props) => `1px solid ${props.theme.point2}`};
+  border-radius: 2.6rem;
+  margin-bottom: 1.5rem;
+  font-size: 1.2rem;
+  background-color: ${(props) => props.theme.point2};
+  color: white;
+  opacity: 0.7;
+  cursor: pointer;
+  transition: opacity 0.2s linear;
+
+  &:hover {
+    ${(props) => (props.isDisabled ? 'cursor: not-allowed' : 'opacity: 1')}
+  }
+`;


### PR DESCRIPTION
## 📑 제목
회원 가입 시 조건에 맞게 입력하였다면 인증코드를 입력할 수 있는 컴포넌트 제작
![image](https://user-images.githubusercontent.com/65718183/175313524-dd94def7-155d-4c47-871a-3e2a09fc6167.png)

## 📎 관련 이슈
closes #59 

## ✔️ 셀프 체크리스트
- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] Test Code를 작성하였나요?
  
## 💬 작업 내용
- Email certification을 위한 코드 입력 컴포넌트 구현
   1. email, password validation을 만족한 후 회원가입 버튼을 누르면 화면에 출력
   2. 이후 회원가입 버튼 텍스트 변경과 disabled 설정
   3. CustomForm에 존재하던 button style 분리
 
## 🚧 PR 특이 사항
❌

## 🕰 실제 소요 시간
작업을 시작하기 부터 PR을 올리기 까지 소요된 시간입니다.  
1.5h
