### PR TITLE
feature/#65 스키마 세팅

### DIFF
--- a/server/src/db/schemas/AuthNumberSchema.ts
+++ b/server/src/db/schemas/AuthNumberSchema.ts
@@ -1,0 +1,28 @@
+import { Schema } from 'mongoose';
+
+const AuthNumberSchema = new Schema(
+  {
+    email: {
+      type: String,
+      required: true,
+    },
+    authNumber: {
+      type: String,
+      required: true,
+    },
+    flag: {
+      type: String,
+      required: true,
+    },
+    createdAt: {
+        type: Date,
+        expires: process.env.DEFAULT_EXPIRATION,
+        default: Date.now,
+    }
+  },
+  {
+    collection: 'authNumber',
+  }
+);
+
+export { AuthNumberSchema };


### PR DESCRIPTION
## 📑 제목
![image](https://user-images.githubusercontent.com/93240443/175350431-ae342750-6fcd-49cb-96a8-0e52fbb52888.png)

## 📎 관련 이슈
closes #65 

## ✔️ 셀프 체크리스트
- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [x] Test Code를 작성하였나요?
  
## 💬 작업 내용
Redis에 메일/패스워드 인증 번호를 저장 하는 도중 오류 발생 시 MongoDB를 사용하여 데이터 손실을 해결하기 위한 스키마 구현 
   
  
email : 인증 번호를 발송한 이메일 주소   
authNumber : 발급한 인증번호(해쉬화해서 들어갈 에정입니다.)   
flag : email인증 번호와 password인증 번호를 구분하기 위한 칼럼 (emailAuth/passwordAuth)   
createAt : 생성된 시간으로 expire을 설정하여 만료 기한을 설정하였습니다.   

 
## 🚧 PR 특이 사항
없습니다.

## 🕰 실제 소요 시간
1h
