### PR TITLE
feature/#98 유저정보수정 

### DIFF
--- a/server/src/db/models/UserModel.ts
+++ b/server/src/db/models/UserModel.ts
@@ -1,4 +1,4 @@
-import { model,Types } from 'mongoose';
+import { model, Types } from 'mongoose';
 import { UserSchema } from '../schemas/UserSchema';
 
 const User = model('users', UserSchema);
@@ -7,7 +7,7 @@ export interface UserRefreshToken {
   kakao?: string;
   github?: string;
   google?: string;
-  base?:string;
+  base?: string;
 }
 
 export interface UserInfo {
@@ -28,12 +28,18 @@ export interface UserData {
 }
 
 export interface ToUpdateRefreshToken {
-    userId: object;
-    update: {
-      [key: string]: UserRefreshToken;
-    };
-  }
-  
+  userId: object;
+  update: {
+    [key: string]: UserRefreshToken;
+  };
+}
+
+interface ToUpdate {
+  email: string;
+  update: {
+    [key: string]: string | number | UserRefreshToken;
+  };
+}
 
 export class UserModel {
   async findByEmail(email: string): Promise<UserData> {
@@ -52,7 +58,10 @@ export class UserModel {
     return createdNewUser;
   }
 
-  async updateRefreshToken({ userId, update }: ToUpdateRefreshToken): Promise<UserData> {
+  async updateRefreshToken({
+    userId,
+    update,
+  }: ToUpdateRefreshToken): Promise<UserData> {
     const filter = { _id: userId };
     const option = { returnOriginal: false };
 
@@ -60,6 +69,13 @@ export class UserModel {
     return updatedUser;
   }
 
+  async update({ email, update }: ToUpdate): Promise<UserData> {
+    const filter = { email: email };
+    const option = { returnOriginal: false };
+
+    const updatedUser = await User.findOneAndUpdate(filter, update, option);
+    return updatedUser;
+  }
 }
 
 const userModel = new UserModel();

--- a/server/src/middlewares/TokenRequestMatch.ts
+++ b/server/src/middlewares/TokenRequestMatch.ts
@@ -1,0 +1,31 @@
+import { Request, Response, NextFunction } from 'express';
+
+async function tokenRequestMatch(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  try {
+    if (req.currentUserEmail !== req.body.email) {
+      console.log(
+        '사용자 요청이 있었습니다. 하지만 권한이 없거나 적절하지 않습니다.'
+      );
+      res.status(403).json({
+        result: 'forbidden-approach',
+        reason: '로그인된 유저는 요청할 수 있는 권한이 없습니다.',
+      });
+
+      return;
+    }
+    next();
+  } catch (error) {
+    res.status(403).json({
+      result: 'forbidden-approach',
+      reason: '정상적인 토큰이 아닙니다.',
+    });
+    console.log(error);
+    return;
+  }
+}
+
+export { tokenRequestMatch };

--- a/server/src/middlewares/index.ts
+++ b/server/src/middlewares/index.ts
@@ -1,1 +1,2 @@
 export * from './AuthJWT';
+export * from './TokenRequestMatch';

--- a/server/src/routers/UserRouter.ts
+++ b/server/src/routers/UserRouter.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import is from '@sindresorhus/is';
 import { userService } from '../services';
-import { authJwt } from '../middlewares';
+import { authJwt, tokenRequestMatch } from '../middlewares';
 
 const userRouter = Router();
 
@@ -15,26 +15,24 @@ userRouter.post('/register', async (req, res, next) => {
     }
 
     // req (request) 에서 데이터 가져오기
-    interface user{
-        nickName:string;
-        email:string;
-        password:string;
-    }
-        
-    const {nickName,email,password}:user = req.body
-        
-    let regexEmail = /^(([^<>()[\]\.,;:\s@"]+(\.[^<>()[\]\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-    if (!regexEmail.test(email)){
-      throw new Error(
-        '이메일 형식이 올바르지 않습니다.'
-      );
+    interface user {
+      nickName: string;
+      email: string;
+      password: string;
     }
 
-    let regexPassword = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[$@$!%*#?&])[A-Za-z\d$@$!%*#?&]{8,20}$/;
-    if (!regexPassword.test(password)){
-      throw new Error(
-        '비밀번호 형식이 올바르지 않습니다.'
-      );
+    const { nickName, email, password }: user = req.body;
+
+    let regexEmail =
+      /^(([^<>()[\]\.,;:\s@"]+(\.[^<>()[\]\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+    if (!regexEmail.test(email)) {
+      throw new Error('이메일 형식이 올바르지 않습니다.');
+    }
+
+    let regexPassword =
+      /^(?=.*[A-Za-z])(?=.*\d)(?=.*[$@$!%*#?&])[A-Za-z\d$@$!%*#?&]{8,20}$/;
+    if (!regexPassword.test(password)) {
+      throw new Error('비밀번호 형식이 올바르지 않습니다.');
     }
 
     // 위 데이터를 유저 db에 추가하기
@@ -63,7 +61,7 @@ userRouter.post('/login', async function (req, res, next) {
     // const email: string = req.body.email;
     // const password: string = req.body.password;
 
-    const { email,password } = req.body;
+    const { email, password } = req.body;
 
     // 위 데이터가 db에 있는지 확인하고,
     // db 있을 시 로그인 성공 및, 토큰 받아오기
@@ -77,15 +75,56 @@ userRouter.post('/login', async function (req, res, next) {
 
 userRouter.get('/random', async (req, res, next) => {
   try {
-
     const randomLink = await userService.findRandomUser();
 
     res.status(200).json(randomLink);
-    
   } catch (error) {
     next(error);
   }
 });
 
+userRouter.put('/', authJwt, tokenRequestMatch, async (req, res, next) => {
+  try {
+    // content-type 을 application/json 로 프론트에서
+    // 설정 안 하고 요청하면, body가 비어 있게 됨.
+    if (is.emptyObject(req.body)) {
+      throw new Error(
+        'headers의 Content-Type을 application/json으로 설정해주세요'
+      );
+    }
+
+    // body data 로부터 업데이트할 사용자 정보를 추출함.
+    const email: string = req.body.email;
+    const password: string = req.body.password;
+    const nickName: string = req.body.nickName;
+
+    // body data로부터, 확인용으로 사용할 현재 비밀번호를 추출함.
+    const currentPassword = req.body.currentPassword;
+
+    // currentPassword 없을 시, 진행 불가
+    if (!currentPassword) {
+      throw new Error('정보를 변경하려면, 현재의 비밀번호가 필요합니다.');
+    }
+
+    const userInfoRequired = { email, currentPassword };
+
+    // 위 데이터가 undefined가 아니라면, 즉, 프론트에서 업데이트를 위해
+    // 보내주었다면, 업데이트용 객체에 삽입함.
+    const toUpdate = {
+      ...(nickName && { nickName }),
+      ...(password && { password }),
+    };
+
+    // 사용자 정보를 업데이트함.
+    const updatedUserInfo = await userService.setUser(
+      userInfoRequired,
+      toUpdate
+    );
+
+    res.status(200).json(updatedUserInfo);
+  } catch (error) {
+    next(error);
+  }
+});
 
 export { userRouter };

--- a/server/src/routers/UserRouter.ts
+++ b/server/src/routers/UserRouter.ts
@@ -98,6 +98,12 @@ userRouter.put('/', authJwt, tokenRequestMatch, async (req, res, next) => {
     const password: string = req.body.password;
     const nickName: string = req.body.nickName;
 
+    let regexPassword =
+      /^(?=.*[A-Za-z])(?=.*\d)(?=.*[$@$!%*#?&])[A-Za-z\d$@$!%*#?&]{8,20}$/;
+    if (!regexPassword.test(password)) {
+      throw new Error('비밀번호 형식이 올바르지 않습니다.');
+    }
+
     // body data로부터, 확인용으로 사용할 현재 비밀번호를 추출함.
     const currentPassword = req.body.currentPassword;
 

--- a/server/src/services/UserService.ts
+++ b/server/src/services/UserService.ts
@@ -1,17 +1,12 @@
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
-import {
-  userModel,
-  UserModel,
-  UserInfo,
-  UserData,
-} from '../db';
+import { userModel, UserModel, UserInfo, UserData } from '../db';
 
 interface UserRefreshToken {
   kakao?: string;
   github?: string;
   google?: string;
-  base?:string;
+  base?: string;
 }
 
 interface LoginInfo {
@@ -31,19 +26,27 @@ interface ToUpdateRefreshToken {
   };
 }
 
+interface UserInfoRequired {
+  email: string;
+  currentPassword: string;
+}
+
 class UserService {
   constructor(private userModel: UserModel) {}
 
-   async findUserByEmail(email: string): Promise<UserData> {
+  async findUserByEmail(email: string): Promise<UserData> {
     // 객체 destructuring
-  
+
     // 이메일 중복 확인
     const user = await this.userModel.findByEmail(email);
-    
+
     return user;
   }
 
-  async updateRefreshToken({ userId, update }: ToUpdateRefreshToken): Promise<UserData> {
+  async updateRefreshToken({
+    userId,
+    update,
+  }: ToUpdateRefreshToken): Promise<UserData> {
     const filter = { _id: userId };
     const option = { returnOriginal: false };
 
@@ -53,7 +56,6 @@ class UserService {
     });
     return updatedUser;
   }
-
 
   // 일반 회원가입
   async addUser(userInfo: UserInfo): Promise<UserData> {
@@ -71,14 +73,18 @@ class UserService {
     // 비밀번호 해쉬화
     const hashedPassword = await bcrypt.hash(password, 10);
 
-    const newUserInfo = { nickName, email, password: hashedPassword,userType:"base"};
+    const newUserInfo = {
+      nickName,
+      email,
+      password: hashedPassword,
+      userType: 'base',
+    };
 
     // db에 저장
     const createdNewUser = await this.userModel.create(newUserInfo);
 
     return createdNewUser;
   }
-
 
   async getUserToken(loginInfo: LoginInfo): Promise<LoginResult> {
     // 객체 destructuring
@@ -109,35 +115,83 @@ class UserService {
     // 로그인 성공 -> JWT 웹 토큰 생성
     const secretKey = process.env.JWT_SECRET_KEY || 'secret-key';
 
-    const accessToken = jwt.sign({ userEmail: user.email, userNickname: user.nickName }, secretKey,{
-      expiresIn: "30s",
-    });
+    const accessToken = jwt.sign(
+      { userEmail: user.email, userNickname: user.nickName },
+      secretKey,
+      {
+        expiresIn: '30s',
+      }
+    );
 
-    const refreshToken = jwt.sign({}, secretKey,{
-      expiresIn: "50s",
+    const refreshToken = jwt.sign({}, secretKey, {
+      expiresIn: '50s',
     });
 
     const updatedUser = await this.userModel.updateRefreshToken({
       userId,
-      update: {refreshToken : {base: refreshToken} },
+      update: { refreshToken: { base: refreshToken } },
     });
-
 
     return { accessToken, refreshToken };
   }
 
   // 랜덤 유저 링크 생성
   async findRandomUser(): Promise<String> {
-
     const randomUser = await this.userModel.findByRandom();
 
-    const {_id } = randomUser;
-    
+    const { _id } = randomUser;
 
-    const randomLink = _id.toString()
-    
+    const randomLink = _id.toString();
+
     return randomLink;
+  }
 
+  // 유저정보 수정, 현재 비밀번호가 있어야 수정 가능함.
+  async setUser(
+    userInfoRequired: UserInfoRequired,
+    toUpdate: Partial<UserInfo>
+  ): Promise<UserData> {
+    // 객체 destructuring
+    const { email, currentPassword } = userInfoRequired;
+
+    // 우선 해당 id의 유저가 db에 있는지 확인
+    let user = await this.userModel.findByEmail(email);
+
+    // db에서 찾지 못한 경우, 에러 메시지 반환
+    if (!user) {
+      throw new Error('가입 내역이 없습니다. 다시 한 번 확인해 주세요.');
+    }
+
+    // 비밀번호 일치 여부 확인
+    const correctPasswordHash = user.password;
+    const isPasswordCorrect = await bcrypt.compare(
+      currentPassword,
+      correctPasswordHash
+    );
+
+    if (!isPasswordCorrect) {
+      throw new Error(
+        '현재 비밀번호가 일치하지 않습니다. 다시 한 번 확인해 주세요.'
+      );
+    }
+
+    // 이제 업데이트 시작
+
+    // 비밀번호도 변경하는 경우에는 해쉬화 해주어야 함.
+    const { password } = toUpdate;
+
+    if (password) {
+      const newPasswordHash = await bcrypt.hash(password!, 10);
+      toUpdate.password = newPasswordHash;
+    }
+
+    // 업데이트 진행
+    user = await this.userModel.update({
+      email,
+      update: toUpdate,
+    });
+
+    return user;
   }
 }
 


### PR DESCRIPTION
## 📑 제목
유저정보 수정 및 request 요청하는 유저와 로그인된(토큰을 보유한) 유저의 일치를 확인하는 미들웨어 생성

## 📎 관련 이슈
closes #98

## ✔️ 셀프 체크리스트
- [v] Warning Message가 발생하지 않았나요?
- [v] Coding Convention을 준수했나요?
- [ ] Test Code를 작성하였나요?
  
## 💬 작업 내용
- 유저정보 수정 API 구현
- request 요청하는 유저와 로그인된(토큰을 보유한) 유저의 일치를 확인하는 미들웨어 생성

 
## 🚧 PR 특이 사항
- merge 사유 : 다음 작업을 진행하기 위해 After Issue: 
[[BE] 메인 페이지]-[API]-[유저정보수정]

## 🕰 실제 소요 시간
2h
