### PR TITLE
feature/#105 회원탈퇴API 구현

### DIFF
--- a/server/src/db/models/UserModel.ts
+++ b/server/src/db/models/UserModel.ts
@@ -76,6 +76,11 @@ export class UserModel {
     const updatedUser = await User.findOneAndUpdate(filter, update, option);
     return updatedUser;
   }
+
+  async deleteById(email: string): Promise<{ deletedCount: number }> {
+    const result = await User.deleteOne({ email: email });
+    return result;
+  }
 }
 
 const userModel = new UserModel();

--- a/server/src/routers/UserRouter.ts
+++ b/server/src/routers/UserRouter.ts
@@ -88,7 +88,7 @@ userRouter.get('/random', async (req, res, next) => {
   }
 });
 
-userRouter.patch('/', authJwt, tokenRequestMatch, async (req, res, next) => {
+userRouter.patch('/', authJwt, async (req, res, next) => {
   try {
     // content-type 을 application/json 로 프론트에서
     // 설정 안 하고 요청하면, body가 비어 있게 됨.
@@ -133,6 +133,36 @@ userRouter.patch('/', authJwt, tokenRequestMatch, async (req, res, next) => {
     );
 
     res.status(200).json(updatedUserInfo);
+  } catch (error) {
+    next(error);
+  }
+});
+
+userRouter.delete('/', authJwt, async (req, res, next) => {
+  try {
+    // content-type 을 application/json 로 프론트에서
+    // 설정 안 하고 요청하면, body가 비어 있게 됨.
+    if (is.emptyObject(req.body)) {
+      throw new Error(
+        'headers의 Content-Type을 application/json으로 설정해주세요'
+      );
+    }
+
+    // body data로부터, 확인용으로 사용할 현재 비밀번호를 추출함.
+    const password: string = req.body.password;
+
+    // Password 없을 시, 진행 불가
+    if (!password) {
+      throw new Error('정보를 변경하려면, 현재의 비밀번호가 필요합니다.');
+    }
+
+    // 사용자 정보를 삭제함.
+    const deleteResult = await userService.deleteUserData(
+      req.currentUserEmail,
+      password
+    );
+
+    res.status(200).json(deleteResult);
   } catch (error) {
     next(error);
   }

--- a/server/src/services/UserService.ts
+++ b/server/src/services/UserService.ts
@@ -36,7 +36,6 @@ class UserService {
   async findUserByEmail(email: string): Promise<UserData> {
     // 객체 destructuring
 
-    // 이메일 중복 확인
     const user = await this.userModel.findByEmail(email);
 
     return user;
@@ -201,6 +200,40 @@ class UserService {
     const userLink = _id.toString();
 
     return userLink;
+  }
+
+  async deleteUserData(
+    email: string,
+    password: string
+  ): Promise<{ message: string }> {
+    let user = await this.userModel.findByEmail(email);
+
+    // db에서 찾지 못한 경우, 에러 메시지 반환
+    if (!user) {
+      throw new Error('가입 내역이 없습니다. 다시 한 번 확인해 주세요.');
+    }
+
+    // 비밀번호 일치 여부 확인
+    const correctPasswordHash = user.password;
+    const isPasswordCorrect = await bcrypt.compare(
+      password,
+      correctPasswordHash
+    );
+
+    if (!isPasswordCorrect) {
+      throw new Error(
+        '현재 비밀번호가 일치하지 않습니다. 다시 한 번 확인해 주세요.'
+      );
+    }
+
+    const { deletedCount } = await this.userModel.deleteById(email);
+
+    // 삭제에 실패한 경우, 에러 메시지 반환
+    if (deletedCount === 0) {
+      throw new Error(`${email} 님의 회원탈퇴를 실패하였습니다.`);
+    }
+
+    return { message: `${email} 님의 회원탈퇴하였습니다.` };
   }
 }
 


### PR DESCRIPTION
## 📑 제목
회원탈퇴API 구현 및 TokenRequestMatch 미들웨어 사용하지 않음

## 📎 관련 이슈
closes #105 

## ✔️ 셀프 체크리스트
- [v] Warning Message가 발생하지 않았나요?
- [v] Coding Convention을 준수했나요?
- [ ] Test Code를 작성하였나요?
  
## 💬 작업 내용
- 회원탈퇴API 구현    

- TokenRequestMatch 미들웨어 사용하지 않음
   사유 : req의 파라미터를 사용하지 않으므로써 토큰의 있는 정보만 가지고 판단하기 때문에 사용할 이유가 없다고 판단함
             추후에 req.params을 사용할 경우 사용할 예정
 
## 🚧 PR 특이 사항
- TokenRequestMatch 미들웨어 사용하지 않음
   사유 : req의 파라미터를 사용하지 않으므로써 토큰의 있는 정보만 가지고 판단하기 때문에 사용할 이유가 없다고 판단함
             추후에 req.params을 사용할 경우 사용할 예정   

- merge 사유 : 다음 작업을 위해 After Issue: #93 
[[BE] 메인 페이지]-[API]-[유저회원탈퇴]

## 🕰 실제 소요 시간
1h
