### PR TITLE
feature/#89 토핑 상세보기 구현

### DIFF
--- a/client/src/pages/main-page/MainPage.tsx
+++ b/client/src/pages/main-page/MainPage.tsx
@@ -17,6 +17,7 @@ import riceCakeImg from '@/assets/images/riceCake.png';
 import Topping from './components/Topping';
 import MockData from './MockData.json';
 import Loading from '@/components/Loading';
+import Detail from './components/Detail';
 
 const ratio = theme.windowHeight / 1500;
 const location1 = { top: 15, left: 32, width: 188 * ratio };
@@ -90,7 +91,6 @@ const MainPage: React.FC = () => {
       setLoading(false);
     }, 500);
   }, [data]);
-
   return (
     <Wrapper loading={loading}>
       <div>
@@ -115,6 +115,8 @@ const MainPage: React.FC = () => {
             })}
 
             <Footer nextPage={nextPage} prevPage={prevPage} />
+
+            <Detail nickname={''} article={''} />
           </>
         )}
       </div>

--- a/client/src/pages/main-page/components/ArticleForm.tsx
+++ b/client/src/pages/main-page/components/ArticleForm.tsx
@@ -1,0 +1,25 @@
+import { Wrapper, NicknameInput, ArticleInput } from './ArticleFormStyle';
+
+interface ArticleProps {
+  children: React.ReactNode;
+  nickname: string | '';
+  article: string | '';
+}
+
+const ArticleForm: React.FC<ArticleProps> = ({
+  children,
+  nickname,
+  article,
+}) => {
+  return (
+    <Wrapper>
+      <label htmlFor="nickname">닉네임</label>
+      <NicknameInput type="text" name="nickname" value={nickname} disabled />
+      <label htmlFor="article">내용</label>
+      <ArticleInput name="article" disabled value={article} />
+      {children}
+    </Wrapper>
+  );
+};
+
+export default ArticleForm;

--- a/client/src/pages/main-page/components/ArticleFormStyle.tsx
+++ b/client/src/pages/main-page/components/ArticleFormStyle.tsx
@@ -1,0 +1,38 @@
+import styled from 'styled-components';
+import { DeviceViewport } from '@/types/interfaces';
+
+export const Wrapper = styled.div`
+  display: flex;
+  width: 100%;
+  height: 80%;
+  padding: 0 1.5rem;
+  /* background-color: rgba(255, 255, 255, 0.7); */
+  flex-direction: column;
+  justify-content: center;
+
+  & label {
+    font-size: 1.3rem;
+  }
+
+  & input,
+  & textarea {
+    width: 100%;
+    font-size: 1.2rem;
+    margin: 1rem 0;
+  }
+`;
+
+export const NicknameInput = styled.input`
+  padding: 0.4rem;
+  background-color: rgba(255, 255, 255, 0.5);
+  /* border-bottom: 3px solid ${(props) => props.theme.point2}; */
+`;
+
+export const ArticleInput = styled.textarea`
+  padding: 0.4rem;
+  resize: none;
+  height: 30vh;
+  background-color: rgba(255, 255, 255, 0.5);
+  line-height: 1.8rem;
+  /* border: 3px solid ${(props) => props.theme.point2}; */
+`;

--- a/client/src/pages/main-page/components/Detail.tsx
+++ b/client/src/pages/main-page/components/Detail.tsx
@@ -1,0 +1,32 @@
+import useDeviceViewport from '@/common/hooks/useDeviceViewport';
+import React, { PropsWithChildren } from 'react';
+import styled from 'styled-components';
+import ArticleForm from './ArticleForm';
+import { Wrapper, Background } from './DetailStyle';
+interface DetailProps {
+  nickname: string | '';
+  article: string | '';
+}
+
+const SubmitButton = styled.button`
+  width: 100%;
+  padding: 0.4rem 0;
+  background-color: ${(props) => props.theme.point2};
+  border-radius: 2rem;
+  font-size: 1.4rem;
+  color: #fff;
+`;
+
+const Detail: React.FC<DetailProps> = ({ nickname, article }) => {
+  return (
+    <Background>
+      <Wrapper>
+        <ArticleForm nickname={nickname} article={article}>
+          <SubmitButton>종료</SubmitButton>
+        </ArticleForm>
+      </Wrapper>
+    </Background>
+  );
+};
+
+export default Detail;

--- a/client/src/pages/main-page/components/DetailStyle.tsx
+++ b/client/src/pages/main-page/components/DetailStyle.tsx
@@ -1,0 +1,31 @@
+import { DeviceViewport } from '@/types/interfaces';
+import styled, { css } from 'styled-components';
+
+const Wrapper = styled.div<DeviceViewport>`
+  position: absolute;
+  width: 90%;
+  max-width: 468px;
+  border-radius: 5%;
+  padding-top: 2%;
+  padding-bottom: 2%;
+  background-color: aliceblue;
+  opacity: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Background = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100vh;
+  width: 100vw;
+  z-index: 3;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(0, 0, 0, 0.2);
+`;
+
+export { Wrapper, Background };


### PR DESCRIPTION
## 📑 토핑 상세보기 화면

- 예시 화면
<img width="1326" alt="스크린샷 2022-06-29 오후 2 43 41" src="https://user-images.githubusercontent.com/59363543/176360552-a70ada77-b475-44f1-89a5-527d8e2648bc.png">

- 반응형 확인
<img width="1009" alt="스크린샷 2022-06-29 오후 2 43 33" src="https://user-images.githubusercontent.com/59363543/176360534-f3340a29-4efb-4560-a82b-54c5f192a04e.png">


## 📎 관련 이슈
resolve #89 

## ✔️ 셀프 체크리스트
- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?

  
## 💬 작업 내용

- 배경 블러처리
- 화면 크기에 디자인이 깨지지 않도록 적용
- 글 props 전달 
 
## 🚧 PR 특이 사항

없음

[FE] 상세 페이지 | 상세페이지 | 글 화면 구현


## 🕰 실제 소요 시간
작업을 시작하기 부터 PR을 올리기 까지 소요된 시간입니다.  
2(시간)
