### PR TITLE
feature#131 access/Refresh 토큰 미들웨어 수정 

### DIFF
--- a/server/src/middlewares/AuthJWT.ts
+++ b/server/src/middlewares/AuthJWT.ts
@@ -5,7 +5,23 @@ import { userService } from '../services';
 
 async function authJwt(req: Request, res: Response, next: NextFunction) {
   // request 헤더로부터 authorization bearer 토큰을 받음.
-  const userAccessToken = req.headers['authorization']?.split(' ')[1];
+  // const userAccessToken = req.headers['authorization']?.split(' ')[1];
+
+  var accessCookies = req.headers['cookie']?.split(';').map(function (element) {
+    let elements = element.split('=');
+    return {
+      key: elements[0].replace(/(\s*)/g, ''),
+      value: elements[1],
+    };
+  });
+
+  console.log(accessCookies);
+
+  const accessCookie = accessCookies?.find((token) => token.key === 'user');
+  console.log(accessCookie);
+  console.log(accessCookie?.value);
+
+  const userAccessToken = accessCookie?.value;
 
   // 이 토큰은 jwt 토큰 문자열이거나, 혹은 "null" 문자열이거나, undefined임.
   // 토큰이 "null" 일 경우, login_required 가 필요한 서비스 사용을 제한함.


### PR DESCRIPTION
## 📑 제목
access/Refresh 토큰 미들웨어 수정 

## 📎 관련 이슈
closes #131 

## ✔️ 셀프 체크리스트
- [v] Warning Message가 발생하지 않았나요?
- [v] Coding Convention을 준수했나요?
- [ ] Test Code를 작성하였나요?
  
## 💬 작업 내용
기존에 req.headers['authorization']으로 받아오는 형식을 변경 -> req.headers['cookie']   

**사유** :    
쿠키를 서버에서 클라이언트로 보내기 위해 res.cookie를 사용했으나    
httponly 옵션으로 인해 클라언트에서 res.cookie를 꺼내서 사용할 수 가 없는 관계로    
 req.headers['authorization']에 담겨서 보낼 수가 없다.     
httponly 옵션을 제거하는 방법이 있지만 보안 위험을 고려해 옵션을 제거하지 않고      
req.headers['cookie']로 쿠키를 꺼내오는 방법을 채택하였다. 
 
## 🚧 PR 특이 사항
merge 사유 : 프론트에서 테스팅하기 위해

## 🕰 실제 소요 시간
1h
