### PR TITLE
feature/#160 비밀번호 분실 flag값 email -> password수정

### DIFF
--- a/server/src/routers/UserRouter.ts
+++ b/server/src/routers/UserRouter.ts
@@ -329,7 +329,7 @@ userRouter.post('/password-auth', async (req, res, next) => {
     console.log(typeof redisData.authNumber);
 
     if (typeof redisData.authNumber == 'undefined') {
-      const flag: string = 'email';
+      const flag: string = 'password';
       const toFindAuthNumber = {
         email: email,
         flag: flag,
@@ -409,7 +409,7 @@ userRouter.post('/password-mail', async (req, res, next) => {
 
     if (!redisSave || redisSave < 1) {
       //dbtest
-      const flag: string = 'email';
+      const flag: string = 'password';
       const authNumber = generatedAuthNumber;
       const identifierNumber = generatedIdentifierNumber;
       const toInsertAuthNumberInfo = {


### PR DESCRIPTION
## 📑 제목
비밀번호 분실 flag값 email -> password수정

## 📎 관련 이슈
closes #160 

## ✔️ 셀프 체크리스트
- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [ ] Test Code를 작성하였나요?
  
## 💬 작업 내용
![image](https://user-images.githubusercontent.com/93240443/176731620-893530d2-0e23-4d4e-bbe2-198cd48b73d5.png)
   
flag 필드는 이메일 인증을 위한 데이터인지 password분실을 위한 데이터인지를 판별하는 것으로    
비밀번호 분실 api를 사용하지만 flag에 email 값이 들어가는 것을 password로 수정
 
## 🚧 PR 특이 사항

[[BE] 로그인 화면]-[API]-[비밀번호찾기]

## 🕰 실제 소요 시간
0.1h
