### PR TITLE
feature/#185 Refresh/Access Token 인증시간 수정

### DIFF
--- a/server/src/middlewares/AuthJWT.ts
+++ b/server/src/middlewares/AuthJWT.ts
@@ -67,7 +67,7 @@ async function authJwt(req: Request, res: Response, next: NextFunction) {
           },
           secretKey,
           {
-            expiresIn: '1m',
+            expiresIn: '1h',
           }
         );
 
@@ -99,7 +99,7 @@ async function authJwt(req: Request, res: Response, next: NextFunction) {
       // access token은 유효하지만, refresh token은 만료된 경우 ->  refresh token 재발급
       if (verifyRefreshToken == 'jwt expired') {
         const newRefreshToken = jwt.sign({}, secretKey, {
-          expiresIn: '3m',
+          expiresIn: '24h',
         });
 
         const updatedUser = await userService.updateRefreshToken({

--- a/server/src/services/UserService.ts
+++ b/server/src/services/UserService.ts
@@ -131,12 +131,12 @@ class UserService {
       },
       secretKey,
       {
-        expiresIn: '1m',
+        expiresIn: '1h',
       }
     );
 
     const refreshToken = jwt.sign({}, secretKey, {
-      expiresIn: '3m',
+      expiresIn: '24h',
     });
 
     const updatedUser = await this.userModel.updateRefreshToken({


### PR DESCRIPTION
## 📑 제목
 Refresh/Access Token 인증시간 수정

## 📎 관련 이슈
closes #185 

## ✔️ 셀프 체크리스트
- [v] Warning Message가 발생하지 않았나요?
- [v] Coding Convention을 준수했나요?
- [ ] Test Code를 작성하였나요?
  
## 💬 작업 내용
- access token : 1m -> 1h
- refresh token : 3m -> 24h
 
## 🚧 PR 특이 사항
- merge 사유 : 원활한 정상적인 프로그램을 돌리기위해

## 🕰 실제 소요 시간
0.1h
