### PR TITLE
feature/#199 회원가입 폼 비밀번호 확인 추가

### DIFF
--- a/client/src/common/components/form-component/CustomForm.tsx
+++ b/client/src/common/components/form-component/CustomForm.tsx
@@ -1,8 +1,6 @@
 import { useForm } from 'react-hook-form';
 import StyledForm from './CustomFormStyle';
 import { RegisterInputType } from '@/types/interfaces';
-import { MutableRefObject, useRef } from 'react';
-
 interface FormProps {
   children?: React.ReactNode;
   onSubmit: (data: RegisterInputType) => void;
@@ -24,7 +22,6 @@ const CustomForm: React.FC<FormProps> = ({
     watch,
     formState: { errors },
   } = useForm<RegisterInputType>({ mode: 'onChange' });
-  const passwordRef = useRef() as MutableRefObject<HTMLInputElement>;
 
   return (
     <StyledForm onSubmit={handleSubmit(onSubmit)}>

--- a/client/src/common/components/form-component/CustomForm.tsx
+++ b/client/src/common/components/form-component/CustomForm.tsx
@@ -1,6 +1,7 @@
 import { useForm } from 'react-hook-form';
 import StyledForm from './CustomFormStyle';
 import { RegisterInputType } from '@/types/interfaces';
+import { MutableRefObject, useRef } from 'react';
 
 interface FormProps {
   children?: React.ReactNode;
@@ -20,8 +21,10 @@ const CustomForm: React.FC<FormProps> = ({
   const {
     register,
     handleSubmit,
+    watch,
     formState: { errors },
   } = useForm<RegisterInputType>({ mode: 'onChange' });
+  const passwordRef = useRef() as MutableRefObject<HTMLInputElement>;
 
   return (
     <StyledForm onSubmit={handleSubmit(onSubmit)}>
@@ -36,7 +39,7 @@ const CustomForm: React.FC<FormProps> = ({
       </h1>
       <div>
         <label htmlFor="emailInput">
-          Email<span> *</span>
+          Email<span>*</span>
         </label>
         <input
           id="emailInput"
@@ -58,7 +61,7 @@ const CustomForm: React.FC<FormProps> = ({
       </div>
       <div>
         <label htmlFor="passwordInput">
-          Password<span> *</span>
+          Password<span>*</span>
         </label>
         <input
           id="passwordInput"
@@ -83,16 +86,35 @@ const CustomForm: React.FC<FormProps> = ({
         )}
       </div>
       {registerMode && (
-        <div>
-          <label htmlFor="nickName">닉네임</label>
-          <input
-            id="nickName"
-            type="text"
-            {...register('nickName')}
-            placeholder="미 입력시 랜덤으로 주어집니다."
-            disabled={isDisabled}
-          />
-        </div>
+        <>
+          <div>
+            <label htmlFor="nickName">
+              Password Check<span>*</span>
+            </label>
+            <input
+              id="password_check"
+              type="password"
+              {...register('password_check', {
+                validate: (value) => value === watch('password'),
+              })}
+              disabled={isDisabled}
+            />
+            {errors.password_check &&
+              errors.password_check.type === 'validate' && (
+                <p>비밀번호가 일치하지 않습니다.</p>
+              )}
+          </div>
+          <div>
+            <label htmlFor="nickName">닉네임</label>
+            <input
+              id="nickName"
+              type="text"
+              {...register('nickName')}
+              placeholder="미 입력시 랜덤으로 주어집니다."
+              disabled={isDisabled}
+            />
+          </div>
+        </>
       )}
       {children}
     </StyledForm>

--- a/client/src/common/components/form-component/CustomFormStyle.tsx
+++ b/client/src/common/components/form-component/CustomFormStyle.tsx
@@ -25,15 +25,16 @@ const StyledForm = styled.form`
     font-size: 1.5rem;
 
     & > span {
+      padding-left: 0.5rem;
       color: red;
-      font-size: 1rem;
+      font-size: 1.1rem;
     }
   }
 
   & input {
     font-size: 1.2rem;
     width: 100%;
-    border-bottom: 3px solid black;
+    border-bottom: 3px solid gray;
     padding: 0.4rem 0.8rem;
 
     &:focus {
@@ -42,7 +43,7 @@ const StyledForm = styled.form`
   }
 
   & > div {
-    margin-bottom: 3.5rem;
+    margin-bottom: 3.2rem;
   }
 
   & p {

--- a/client/src/pages/register-page/components/RegisterForm.tsx
+++ b/client/src/pages/register-page/components/RegisterForm.tsx
@@ -1,7 +1,6 @@
 import { RegisterInputType } from '@/types/interfaces';
 import CustomForm from '@/common/components/form-component/CustomForm';
-import { RegisterButton, SuccessModal } from './RegisterFormStyle';
-import { Link } from 'react-router-dom';
+import { RegisterButton } from './RegisterFormStyle';
 import { useEffect, useRef, useState } from 'react';
 import useRegister from '../hook/useRegister';
 import EmailCertificationForm from './EmailCertificationForm';

--- a/client/src/types/interfaces.ts
+++ b/client/src/types/interfaces.ts
@@ -10,6 +10,7 @@ interface FormInputType {
 
 interface RegisterInputType extends FormInputType {
   nickName: string;
+  password_check?: string;
   emailAuthNumber: string;
 }
 


### PR DESCRIPTION
## 📑 제목
 - 회원가입 폼 비밀번호 확인 추가
![Animation](https://user-images.githubusercontent.com/65718183/177334216-7340e461-0b62-4780-ba2b-2c88e0e2365d.gif)


## 📎 관련 이슈
resolve #199  

## ✔️ 셀프 체크리스트
- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
  
## 💬 작업 내용
1. 회원가입 폼의 비밀번호 확인 항목을 추가했습니다.
 
## 🚧 PR 특이 사항
❌

## 🕰 실제 소요 시간
0.8h
